### PR TITLE
Add passing squid config verification dependency on service restart

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -89,6 +89,7 @@ class squid (
   anchor{'squid::begin':}
   -> class{'::squid::install':}
   -> class{'::squid::config':}
+  ~> class{'::squid::verify_config':}
   ~> class{'::squid::service':}
   -> anchor{'squid::end':}
 

--- a/manifests/verify_config.pp
+++ b/manifests/verify_config.pp
@@ -1,0 +1,13 @@
+# Class squid::verify_config
+#
+# Verifies Squid config
+
+class squid::verify_config inherits squid {
+
+  exec{'verify-squid-conf':
+    path        => ['/usr/bin/','/usr/sbin','/bin'],
+    command     => "squid -k parse || (echo '#INVALID CONFIG' >> $::squid::config && false)",
+    refreshonly => true
+  }
+
+}


### PR DESCRIPTION
The goal of this is to force a check on the squid config before restarting the service.

Exec['verify-squid-conf'] only runs when there is a change to the squid conf file. If the check command in Exec['verify-squid-conf'] fails, meaning the config is invalid, "#INVALID CONFIG" will be placed in the current config to ensure puppet continues to attempt to update the config. This allows better visibility of the failure. If Exec['verify-squid-conf'] succeeds, squid service is refreshed.


